### PR TITLE
Fixed dstc_process_single_event() timeout issue

### DIFF
--- a/dstc.c
+++ b/dstc.c
@@ -1358,7 +1358,8 @@ int dstc_process_events(int timeout_rel)
     else
         // We have an actual timeout specified, pick the shortest
         // timeout of that and the next DSTC timeout.
-        timeout_rel = (next_dstc_timeout_rel < timeout_rel)?
+        timeout_rel = (next_dstc_timeout_rel != -1 &&
+                       next_dstc_timeout_rel < timeout_rel)?
             next_dstc_timeout_rel:timeout_rel;
 
     // At this point, we are guarnteed that timeout_rel is not -1 (infinite)


### PR DESCRIPTION
Fixed issue where a dstc_process_events() with a provided positive timeout was sometimes treated as a timeout of 0.

25% speedup in thread_stress_test.