### PR TITLE
Now supports nil callbacks to inhibit callback invocation

### DIFF
--- a/dstc.c
+++ b/dstc.c
@@ -414,6 +414,13 @@ dstc_callback_t dstc_activate_callback(dstc_context_t* ctx,
 {
     int ind = 0;
 
+    // If a null pointer was provided as a callback, just pass a 0
+    // around. The callback server will simply not do a callback if
+    // (dstc_callback_t) 0 is presented to it.
+    //
+    if (!callback)
+        return (dstc_callback_t) 0;
+
     if (!ctx)
         ctx = &_dstc_default_context;
 

--- a/dstc.h
+++ b/dstc.h
@@ -277,6 +277,10 @@ typedef dstc_callback_t CBCK;
         return;                                                         \
     }                                                                   \
 
+// Null callback that will generate a no-op on when invoked on the
+// server.
+#define DSTC_CLIENT_CALLBACK_ARG_NULL ((dstc_callback_t) 0)
+
 #define DSTC_CLIENT_CALLBACK_ARG(_func)         \
     dstc_activate_callback(                     \
         0,                                      \
@@ -459,12 +463,18 @@ static inline uint16_t dstc_dyndata_length(dstc_dynamic_data_t* dyndata)
 // Create callback function that serializes and writes to descriptor.
 // If the reliable multicast system has not been started when the
 // client call is made, it is will be done through dstc_setup()
+// If cb_ref is zero, then a null callback function pointer was
+// passed on the client side as a callback argument. In that case.
+// Do not do any callbacks.
 #define DSTC_SERVER_CALLBACK(name, ...)                                 \
     int dstc_##name(dstc_callback_t cb_ref, DECLARE_ARGUMENTS(__VA_ARGS__)) { \
         uint32_t arg_sz = SIZE_ARGUMENTS(__VA_ARGS__);                  \
         uint8_t arg_buf[arg_sz];                                        \
         uint8_t *payload = arg_buf;                                     \
         (void) payload;                                                 \
+                                                                        \
+        if (!cb_ref)                                                    \
+            return 0;                                                   \
                                                                         \
         SERIALIZE_ARGUMENTS(__VA_ARGS__);                               \
         return dstc_queue_callback(0, cb_ref, arg_buf, arg_sz);         \

--- a/examples/callback/callback_client.c
+++ b/examples/callback/callback_client.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include "dstc.h"
 #include "rmc_log.h"
+#include <errno.h>
 
 void get_value_callback(int value);
 
@@ -41,7 +42,6 @@ void double_value_callback(int value)
         puts("Error: doubled value received is not 446688");
         exit(255);
     }
-    exit(0);
 }
 
 DSTC_CLIENT_CALLBACK(double_value_callback, int,);
@@ -61,9 +61,15 @@ int main(int argc, char* argv[])
     puts("Asking servr to double 223344");
     dstc_double_value(223344, DSTC_CLIENT_CALLBACK_ARG(double_value_callback));
 
+    // Do the same thing, but with a nil callback argument
+    dstc_double_value(223344, DSTC_CLIENT_CALLBACK_ARG_NULL);
+
+    // Send -1 to trigger server exit.
+    dstc_double_value(-1, DSTC_CLIENT_CALLBACK_ARG_NULL);
+
     // Process events until callback, which will exit process, is made.
-    while(1)
-        dstc_process_events(-1);
+    while( dstc_process_events(0) != ETIME)
+        ;
 
     exit(0);
 }


### PR DESCRIPTION
A client call of  `dstc_double_value(223344, DSTC_CLIENT_CALLBACK_ARG_NULL);` will send a nil callback reference to the server, which will not send any data over the network to the client when the callback is invoked.


